### PR TITLE
Add color input synchronization

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,12 @@ const update=debounce(()=>{
 },100);
 ['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','mainHeadline','message1','message2','photo','ending'].forEach(id=>{document.getElementById(id).addEventListener('input',update);document.getElementById(id).addEventListener('change',update);});
 ['backgroundTheme','textColor','outlineColor'].forEach(id=>{document.getElementById(id).addEventListener('change',e=>{document.getElementById(id+'Custom').classList.toggle('hidden',e.target.value!=='custom');});});
+[['backgroundPicker','backgroundHex'],['textPicker','textHex'],['outlinePicker','outlineHex']].forEach(([pickerId,hexId])=>{
+  const picker=document.getElementById(pickerId);
+  const hex=document.getElementById(hexId);
+  picker.addEventListener('input',()=>{hex.value=picker.value;});
+  hex.addEventListener('input',()=>{if(/^#([0-9A-Fa-f]{6})$/.test(hex.value))picker.value=hex.value;});
+});
 update();
 document.getElementById('revealForm').addEventListener('submit',async e=>{
   e.preventDefault();


### PR DESCRIPTION
## Summary
- synchronize hex and color picker inputs for background, text, and outline colors

## Testing
- `npm test` *(fails: ENOENT – missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868a06c0648832fb17ac798072e12f1