### PR TITLE
Fix double encoding for photo URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
     m:els.mainHeadline.value.trim(),
     s:els.message1.value.trim(),
     d:els.message2.value.trim(),
-    p:encodeURIComponent(els.photo.value.trim()),
+    p:encodeURIComponent(encodeURIComponent(els.photo.value.trim())),
     e:els.ending.value.trim()
   });
   const base='https://bigreveal.joyjotstudio.store/';


### PR DESCRIPTION
## Summary
- ensure uploaded images survive URL processing by double-encoding the photo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868a06dfa20832f837186611917c449