### PR TITLE
Add copy confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
     <h2 class="text-2xl font-bold mb-4" style="color:#1f2937;">Your Reveal URL is Ready!</h2>
     <div class="flex items-center mb-4">
       <input id="generatedUrl" readonly class="flex-1 px-3 py-2 border border-gray-300 rounded text-sm" />
-      <button id="copyBtn" class="ml-2 px-4 py-2 rounded" style="background-color:#cadcca;color:#1f2937;">Copy</button>
+      <button id="copyBtn" class="ml-2 px-4 py-2 rounded" style="background-color:#cadcca;color:#1f2937;" aria-live="polite">Copy</button>
     </div>
     <a id="previewLink" href="#" target="_blank" class="block text-center py-2 rounded mb-3" style="background-color:#cadcca;color:#1f2937;">Preview Page</a>
     <button id="newBtn" class="w-full py-2 rounded" style="background-color:#cadcca;color:#1f2937;">Create Another</button>
@@ -255,8 +255,12 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
   document.getElementById('urlResult').classList.remove('hidden');
 });
 document.getElementById('copyBtn').addEventListener('click',async()=>{
+  const btn=document.getElementById('copyBtn');
   const url=document.getElementById('generatedUrl').value;
   try{await navigator.clipboard.writeText(url);}catch{const inp=document.getElementById('generatedUrl');inp.select();document.execCommand('copy');}
+  const original=btn.textContent;
+  btn.textContent='Copied!';
+  setTimeout(()=>{btn.textContent=original;},1500);
 });
 document.getElementById('newBtn').addEventListener('click',()=>{document.getElementById('revealForm').reset();document.getElementById('urlResult').classList.add('hidden');update();});
 </script>


### PR DESCRIPTION
## Summary
- provide screen reader announcement for the Copy button
- show a temporary "Copied!" message after clicking Copy

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_b_6868a06f6ee0832fb23b7b0bcfdda481