### PR TITLE
Add loading feedback to URL generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
       <input id="generatedUrl" readonly class="flex-1 px-3 py-2 border border-gray-300 rounded text-sm" />
       <button id="copyBtn" class="ml-2 px-4 py-2 rounded" style="background-color:#cadcca;color:#1f2937;">Copy</button>
     </div>
+    <div id="statusMsg" class="text-sm text-gray-700 mb-3"></div>
     <a id="previewLink" href="#" target="_blank" class="block text-center py-2 rounded mb-3" style="background-color:#cadcca;color:#1f2937;">Preview Page</a>
     <button id="newBtn" class="w-full py-2 rounded" style="background-color:#cadcca;color:#1f2937;">Create Another</button>
   </div>
@@ -231,8 +232,14 @@ const update=debounce(()=>{
 ['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','mainHeadline','message1','message2','photo','ending'].forEach(id=>{document.getElementById(id).addEventListener('input',update);document.getElementById(id).addEventListener('change',update);});
 ['backgroundTheme','textColor','outlineColor'].forEach(id=>{document.getElementById(id).addEventListener('change',e=>{document.getElementById(id+'Custom').classList.toggle('hidden',e.target.value!=='custom');});});
 update();
+const generateBtn=document.querySelector('#revealForm button[type="submit"]');
+const defaultText=generateBtn.textContent;
+const statusEl=document.getElementById('statusMsg');
 document.getElementById('revealForm').addEventListener('submit',async e=>{
   e.preventDefault();
+  generateBtn.disabled=true;
+  const originalText=generateBtn.textContent;
+  generateBtn.textContent='Generating…';
   const params=new URLSearchParams({
     c:getColor(els.backgroundTheme,els.backgroundPicker,els.backgroundHex,''),
     t:getColor(els.textColor,els.textPicker,els.textHex,''),
@@ -246,10 +253,18 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
   });
   const base='https://bigreveal.joyjotstudio.store/';
   let full=`${base}?${params.toString()}`;
+  let shortened=false;
   try{
     const r=await fetch(`https://tinyurl.com/api-create.php?url=${encodeURIComponent(full)}`);
-    if(r.ok){const short=await r.text();if(short.startsWith('http'))full=short;}
+    if(r.ok){
+      const short=await r.text();
+      if(short.startsWith('http')){full=short;shortened=true;}
+    }
   }catch{}
+  statusEl.textContent=shortened?'Short link created.':'Using full link.';
+  setTimeout(()=>{statusEl.textContent='';},3000);
+  generateBtn.disabled=false;
+  generateBtn.textContent=originalText;
   document.getElementById('generatedUrl').value=full;
   document.getElementById('previewLink').href=full;
   document.getElementById('urlResult').classList.remove('hidden');
@@ -258,7 +273,14 @@ document.getElementById('copyBtn').addEventListener('click',async()=>{
   const url=document.getElementById('generatedUrl').value;
   try{await navigator.clipboard.writeText(url);}catch{const inp=document.getElementById('generatedUrl');inp.select();document.execCommand('copy');}
 });
-document.getElementById('newBtn').addEventListener('click',()=>{document.getElementById('revealForm').reset();document.getElementById('urlResult').classList.add('hidden');update();});
+document.getElementById('newBtn').addEventListener('click',()=>{
+  document.getElementById('revealForm').reset();
+  document.getElementById('urlResult').classList.add('hidden');
+  statusEl.textContent='';
+  generateBtn.disabled=false;
+  generateBtn.textContent=defaultText;
+  update();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a status area in the results card
- disable the generate button while processing and display a "Generating…" text
- indicate whether TinyURL shortening succeeded or the full URL is used
- reset status when starting a new form

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6868a078b498832f8517d9619a6f18f7