### PR TITLE
Fix custom outline color div ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <option value="black">Black</option>
             <option value="custom">Custom Color</option>
           </select>
-          <div id="outlineCustom" class="hidden mt-3">
+          <div id="outlineColorCustom" class="hidden mt-3">
             <div class="flex items-center space-x-3">
               <input type="color" id="outlinePicker" class="w-12 h-12 border rounded-lg" value="#ffffff" />
               <input type="text" id="outlineHex" class="flex-1 px-4 py-3 border rounded-lg" pattern="^#([0-9A-Fa-f]{6})$" placeholder="#ffffff" />


### PR DESCRIPTION
## Summary
- rename `outlineCustom` div to `outlineColorCustom` so the toggle script works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ab7dc6a8832f89bc4b9a6578f88e