### PR TITLE
Add photo upload tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,9 +151,29 @@
           <input id="message2" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Coming soon!" />
         </div>
         <div class="md:col-span-2">
-          <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">Photo URL (optional)</label>
-          <input id="photo" type="url" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="https://i.imgur.com/example.jpg" />
-          <p class="text-xs text-gray-500 mt-1">Upload your photo to Imgur and copy the direct link.</p>
+          <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">
+            Photo URL <span class="text-gray-400">(optional)</span>
+            <span class="inline-block relative ml-1 group cursor-help">
+              <span class="bg-gray-400 text-white rounded-full w-4 h-4 text-xs flex items-center justify-center hover:bg-gray-500">?</span>
+              <div class="absolute left-0 top-6 bg-gray-800 text-white text-xs rounded-lg p-3 w-64 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-10 shadow-lg">
+                <p><strong>Steps to upload:</strong></p>
+                <ol class="list-decimal ml-4 space-y-1">
+                  <li>Go to <strong>imgur.com/upload</strong></li>
+                  <li>Drag and drop your photo onto the page</li>
+                  <li>Copy the image link on the right</li>
+                  <li>Paste it here</li>
+                </ol>
+              </div>
+            </span>
+          </label>
+          <input
+            type="url"
+            id="photo"
+            name="photo"
+            placeholder="https://i.imgur.com/yourimage.jpg"
+            class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 transition-all"
+          >
+          <p class="text-xs text-gray-500 mt-1">Upload to Imgur, Postimg, etc., and paste the direct link here.</p>
         </div>
         <div class="md:col-span-2">
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>


### PR DESCRIPTION
## Summary
- add upload instructions tooltip to the `Photo URL` label so users know how to get a link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ab7c6b68832f8d735a532af126fb