### PR TITLE
Fix backgrounds, colors and hover styles

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -296,7 +296,7 @@
         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 transition-all"
       >
       <p class="text-xs text-gray-500 mt-1">This is the main message that will appear on your reveal page.</p>
-      <p class="text-xs font-medium mt-1 text-[#cadcca]">Note: This text will appear in ALL CAPS on your reveal page.</p>
+      <p class="text-xs font-medium mt-1 text-[#c0dcca]">Note: This text will appear in ALL CAPS on your reveal page.</p>
     </div>
 
     <!-- Live Preview: Page 1 -->
@@ -412,9 +412,9 @@
     type="submit"
     form="revealForm"
     class="w-full font-semibold py-4 px-6 rounded-lg transform hover:scale-105 transition-all duration-200 shadow-lg hover:shadow-xl"
-    style="background-color: #cadcca; color: #1f2937;"
+    style="background-color: #c0dcca; color: #1f2937;"
     onmouseover="this.style.backgroundColor='#a8d0b5'"
-    onmouseout="this.style.backgroundColor='#cadcca'"
+    onmouseout="this.style.backgroundColor='#c0dcca'"
   >
     Generate My Reveal URL
   </button>
@@ -436,9 +436,9 @@
         id="copyBtn"
         type="button"
         class="px-4 py-2 rounded transition-colors text-sm font-medium"
-        style="background-color: #cadcca; color: #1f2937;"
+        style="background-color: #c0dcca; color: #1f2937;"
         onmouseover="this.style.backgroundColor='#a8d0b5'"
-        onmouseout="this.style.backgroundColor='#cadcca'"
+        onmouseout="this.style.backgroundColor='#c0dcca'"
       >
         Copy
       </button>
@@ -451,9 +451,9 @@
       href="#"
       target="_blank"
       class="flex-1 text-center py-3 px-4 rounded-lg transition-colors font-medium"
-      style="background-color: #cadcca; color: #1f2937;"
+      style="background-color: #c0dcca; color: #1f2937;"
       onmouseover="this.style.backgroundColor='#a8d0b5'"
-      onmouseout="this.style.backgroundColor='#cadcca'"
+      onmouseout="this.style.backgroundColor='#c0dcca'"
     >
       Preview Page
     </a>
@@ -461,9 +461,9 @@
       id="newRevealBtn"
       type="button"
       class="flex-1 py-3 px-4 rounded-lg transition-colors font-medium"
-      style="background-color: #cadcca; color: #1f2937;"
+      style="background-color: #c0dcca; color: #1f2937;"
       onmouseover="this.style.backgroundColor='#a8d0b5'"
-      onmouseout="this.style.backgroundColor='#cadcca'"
+      onmouseout="this.style.backgroundColor='#c0dcca'"
     >
       Create Another
     </button>
@@ -510,7 +510,7 @@
   };
 
   const themeColors = {
-    beige: '#f3ddbb',
+    beige: '#f3f3f3',
     pink: '#fccac5',
     blue: '#add4fd',
     yellow: '#fef3c7',
@@ -539,7 +539,7 @@
     const outlineVal = elements.outlineColor.value;
     const fontVal = elements.font.value;
 
-    const bgColor = bgVal === 'custom' ? elements.backgroundColorHex.value : themeColors[bgVal] || '#f3ddbb';
+    const bgColor = bgVal === 'custom' ? elements.backgroundColorHex.value : themeColors[bgVal] || '#f3f3f3';
     const textColor = textVal === 'custom' ? elements.textColorHex.value : textVal || '#000000';
     const outlineColor = outlineVal === 'custom' ? elements.outlineColorHex.value : outlineVal || 'transparent';
 
@@ -913,7 +913,7 @@
 <div class="text-center">
   <button
     type="submit"
-    class="bg-[#cadcca] hover:bg-[#a8d0b5] text-gray-800 font-semibold py-3 px-6 rounded-lg shadow-lg transition-all"
+    class="bg-[#c0dcca] hover:bg-[#a8d0b5] text-gray-800 font-semibold py-3 px-6 rounded-lg shadow-lg transition-all"
   >
     Generate Shareable Link
   </button>

--- a/index.html
+++ b/index.html
@@ -13,14 +13,14 @@
   input:focus, select:focus { outline: none; box-shadow: 0 0 0 3px rgba(255,184,141,0.2); border-color:#ffb88d; }
 </style>
 </head>
-<body class="bg-orange-100 min-h-screen py-8">
+<body class="min-h-screen py-8" style="background-color:#ffe4b7;">
 <!-- Password Screen -->
 <div id="passwordScreen" class="max-w-md mx-auto">
   <div class="bg-white rounded-2xl shadow-xl p-8 text-center">
     <h1 class="text-2xl font-bold mb-4" style="color:#1f2937;">Access Required</h1>
     <form id="passwordForm" class="space-y-4">
       <input id="passwordInput" type="password" placeholder="Enter code" class="w-full px-4 py-3 border border-gray-300 rounded-lg text-center font-mono text-lg tracking-wider" />
-      <button type="submit" class="w-full py-3 rounded-lg font-semibold" style="background-color:#c0dcca;color:#1f2937;">Access Template</button>
+      <button type="submit" class="w-full py-3 rounded-lg font-semibold" style="background-color:#c0dcca;color:#1f2937;" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Access Template</button>
       <div id="passwordError" class="text-red-500 text-sm hidden">Incorrect code.</div>
     </form>
   </div>
@@ -116,7 +116,7 @@
       </div>
       <div class="hidden md:block mt-8">
         <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
-        <div id="previewBackground" class="h-40 flex items-center justify-center rounded-lg" style="background-color:#f3ddbb;">
+        <div id="previewBackground" class="h-40 flex items-center justify-center rounded-lg" style="background-color:#f3f3f3;">
           <div id="previewText" class="text-center">
             <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
             <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
@@ -135,10 +135,11 @@
           <label for="mainHeadline" class="block text-sm font-semibold text-gray-700 mb-2">Main Headline</label>
           <input id="mainHeadline" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="We're Expecting!" required />
           <p class="text-xs text-gray-500 mt-1">This text will appear in ALL CAPS.</p>
+          <p class="text-xs font-medium mt-1" style="color:#c0dcca;">Note: This text will appear in ALL CAPS on your reveal page.</p>
         </div>
         <div class="hidden md:block">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
-          <div id="preview1Background" class="h-32 flex items-center justify-center rounded-lg" style="background-color:#f3ddbb;">
+          <div id="preview1Background" class="h-32 flex items-center justify-center rounded-lg" style="background-color:#f3f3f3;">
             <h1 id="preview1Text" class="text-4xl font-bold" style="display:none"></h1>
           </div>
         </div>
@@ -191,7 +192,7 @@
       </div>
       <div class="hidden md:block mt-8">
         <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
-        <div id="preview2Background" class="h-64 flex items-center justify-center rounded-lg" style="background-color:#f3ddbb;">
+        <div id="preview2Background" class="h-64 flex items-center justify-center rounded-lg" style="background-color:#f3f3f3;">
           <div id="preview2Text" class="text-center space-y-3">
             <h2 id="preview2Msg1" class="text-2xl font-bold" style="display:none"></h2>
             <p id="preview2Msg2" class="text-lg" style="display:none"></p>
@@ -203,18 +204,18 @@
     </div>
     <!-- Generate URL -->
     <div class="bg-white rounded-2xl shadow-xl p-8 text-center">
-      <button type="submit" class="w-full py-3 rounded-lg font-semibold" style="background-color:#cadcca;color:#1f2937;">Generate My Reveal URL</button>
+      <button type="submit" class="w-full py-3 rounded-lg font-semibold" style="background-color:#c0dcca;color:#1f2937;" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Generate My Reveal URL</button>
     </div>
   </form>
   <div id="urlResult" class="hidden bg-white rounded-2xl shadow-xl p-8 text-center">
     <h2 class="text-2xl font-bold mb-4" style="color:#1f2937;">Your Reveal URL is Ready!</h2>
     <div class="flex items-center mb-4">
       <input id="generatedUrl" readonly class="flex-1 px-3 py-2 border border-gray-300 rounded text-sm" />
-      <button id="copyBtn" class="ml-2 px-4 py-2 rounded" style="background-color:#cadcca;color:#1f2937;" aria-live="polite">Copy</button>
+      <button id="copyBtn" class="ml-2 px-4 py-2 rounded" style="background-color:#c0dcca;color:#1f2937;" aria-live="polite" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Copy</button>
     </div>
     <div id="statusMsg" class="text-sm text-gray-700 mb-3"></div>
-    <a id="previewLink" href="#" target="_blank" class="block text-center py-2 rounded mb-3" style="background-color:#cadcca;color:#1f2937;">Preview Page</a>
-    <button id="newBtn" class="w-full py-2 rounded" style="background-color:#cadcca;color:#1f2937;">Create Another</button>
+    <a id="previewLink" href="#" target="_blank" class="block text-center py-2 rounded mb-3" style="background-color:#c0dcca;color:#1f2937;" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Preview Page</a>
+    <button id="newBtn" class="w-full py-2 rounded" style="background-color:#c0dcca;color:#1f2937;" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Create Another</button>
   </div>
 </div>
 <script>
@@ -229,11 +230,11 @@
 })();
 const debounce=(fn,delay=100)=>{let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),delay);}};
 const els={backgroundTheme:document.getElementById('backgroundTheme'),backgroundPicker:document.getElementById('backgroundPicker'),backgroundHex:document.getElementById('backgroundHex'),textColor:document.getElementById('textColor'),textPicker:document.getElementById('textPicker'),textHex:document.getElementById('textHex'),outlineColor:document.getElementById('outlineColor'),outlinePicker:document.getElementById('outlinePicker'),outlineHex:document.getElementById('outlineHex'),fontFamily:document.getElementById('fontFamily'),mainHeadline:document.getElementById('mainHeadline'),message1:document.getElementById('message1'),message2:document.getElementById('message2'),photo:document.getElementById('photo'),ending:document.getElementById('ending'),previewBackground:document.getElementById('previewBackground'),previewMain:document.getElementById('previewMain'),previewSub:document.getElementById('previewSub'),preview1Background:document.getElementById('preview1Background'),preview1Text:document.getElementById('preview1Text'),preview2Background:document.getElementById('preview2Background'),preview2Msg1:document.getElementById('preview2Msg1'),preview2Msg2:document.getElementById('preview2Msg2'),preview2Photo:document.getElementById('preview2Photo'),preview2Ending:document.getElementById('preview2Ending')};
-const themes={beige:'#f3ddbb',pink:'#fccac5',blue:'#add4fd',yellow:'#fef3c7',green:'#81a969',purple:'#d2c5fc',gold:'#ffdf9a',white:'#ffffff'};
+const themes={beige:'#f3f3f3',pink:'#fccac5',blue:'#add4fd',yellow:'#fef3c7',green:'#81a969',purple:'#d2c5fc',gold:'#ffdf9a',white:'#ffffff'};
 function applyText(el,color,outline,font){if(!el)return;el.style.color=color;el.style.fontFamily=`'${font}',sans-serif`;if(outline==='transparent'){el.style.textShadow='none';el.style.webkitTextStroke='0';}else{el.style.textShadow=`-1px -1px 0 ${outline},1px -1px 0 ${outline},-1px 1px 0 ${outline},1px 1px 0 ${outline}`;el.style.webkitTextStroke=`1px ${outline}`;}}
 function getColor(selectEl,pickerEl,hexEl,def){const val=selectEl.value;return val==='custom'?(hexEl.value||def):(val in themes?themes[val]:val||def);}
 const update=debounce(()=>{
-  const bg=getColor(els.backgroundTheme,els.backgroundPicker,els.backgroundHex,'#f3ddbb');
+  const bg=getColor(els.backgroundTheme,els.backgroundPicker,els.backgroundHex,'#f3f3f3');
   const text=getColor(els.textColor,els.textPicker,els.textHex,'#000000');
   const outline=getColor(els.outlineColor,els.outlinePicker,els.outlineHex,'transparent');
   const font=els.fontFamily.value;


### PR DESCRIPTION
## Summary
- switch body background to `#ffe4b7`
- update buttons to use `#c0dcca` with hover to `#a8d0b5`
- change live preview background to `#f3f3f3`
- style ALL CAPS note text in green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868ad7004d4832fb55fb967fb847aa2