### PR TITLE
Fix photo param encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
     main:els.mainHeadline.value.trim(),
     sub:els.message1.value.trim(),
     date:els.message2.value.trim(),
-    photo:encodeURIComponent(els.photo.value.trim()),
+    photo:els.photo.value.trim(),
     from:els.ending.value.trim()
   });
   const base='https://bigreveal.joyjotstudio.store/';


### PR DESCRIPTION
## Summary
- remove redundant `encodeURIComponent` for the `photo` parameter

## Testing
- `node - <<'NODE'
const els={photo:{value:'https://example.com/x yz'}};
const params=new URLSearchParams({photo:els.photo.value.trim()});
const base='https://bigreveal.joyjotstudio.store/';
const full=`${base}?${params.toString()}`;
console.log(full);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_6868c00bac4c832f82bf2f2d3f342f68