### PR TITLE
Fix outline color options

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -88,8 +88,16 @@
           <label for="outlineColor" class="block text-sm font-semibold text-gray-700 mb-2">Text Outline Color</label>
           <select id="outlineColor" class="w-full px-4 py-3 border border-gray-300 rounded-lg" required>
             <option value="transparent">None</option>
-            <option value="white">White</option>
-            <option value="black">Black</option>
+            <option value="#000000">Black</option>
+            <option value="#ffffff">White</option>
+            <option value="#374151">Dark Gray</option>
+            <option value="#dc2626">Red</option>
+            <option value="#ea580c">Orange</option>
+            <option value="#ca8a04">Yellow</option>
+            <option value="#16a34a">Green</option>
+            <option value="#2563eb">Blue</option>
+            <option value="#7c3aed">Purple</option>
+            <option value="#ff69b4">Pink</option>
             <option value="custom">Custom Color</option>
           </select>
           <div id="outlineColorCustom" class="hidden mt-3">

--- a/index.html
+++ b/index.html
@@ -88,8 +88,16 @@
           <label for="outlineColor" class="block text-sm font-semibold text-gray-700 mb-2">Text Outline Color</label>
           <select id="outlineColor" class="w-full px-4 py-3 border border-gray-300 rounded-lg" required>
             <option value="transparent">None</option>
-            <option value="white">White</option>
-            <option value="black">Black</option>
+            <option value="#000000">Black</option>
+            <option value="#ffffff">White</option>
+            <option value="#374151">Dark Gray</option>
+            <option value="#dc2626">Red</option>
+            <option value="#ea580c">Orange</option>
+            <option value="#ca8a04">Yellow</option>
+            <option value="#16a34a">Green</option>
+            <option value="#2563eb">Blue</option>
+            <option value="#7c3aed">Purple</option>
+            <option value="#ff69b4">Pink</option>
             <option value="custom">Custom Color</option>
           </select>
           <div id="outlineColorCustom" class="hidden mt-3">


### PR DESCRIPTION
## Summary
- expand outline color dropdown to include more preset choices

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6868c493f8b0832f979271611cb9db46