### PR TITLE
Fix preview layout responsiveness

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -130,13 +130,13 @@
           </select>
         </div>
       </div>
-      </div>
-      <div class="hidden md:block mt-8">
-        <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
-        <div id="previewBackground" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-          <div id="previewText" class="text-center">
-            <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
-            <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
+        <div class="hidden md:flex flex-col items-center">
+          <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
+          <div id="previewBackground" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <div id="previewText" class="text-center break-words">
+              <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
+              <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
+            </div>
           </div>
         </div>
       </div>
@@ -154,10 +154,10 @@
           <p class="text-xs text-gray-500 mt-1">This text will appear in ALL CAPS.</p>
           <p class="text-xs font-medium mt-1" style="color:#c0dcca;">Note: This text will appear in ALL CAPS on your reveal page.</p>
         </div>
-        <div class="hidden md:block">
+        <div class="hidden md:flex flex-col items-center">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
-          <div id="preview1Background" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-            <h1 id="preview1Text" class="text-4xl font-bold" style="display:none"></h1>
+          <div id="preview1Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <h1 id="preview1Text" class="text-4xl font-bold break-words text-center" style="display:none"></h1>
           </div>
         </div>
       </div>
@@ -207,20 +207,20 @@
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
         </div>
-      </div>
-      <div class="hidden md:block mt-8">
-        <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
-        <div id="preview2Background" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-          <div id="preview2Text" class="text-center space-y-3">
-            <h2 id="preview2Msg1" class="text-2xl font-bold" style="display:none"></h2>
-            <p id="preview2Msg2" class="text-lg" style="display:none"></p>
-            <div id="preview2Photo" style="display:none"></div>
-            <p id="preview2Ending" class="italic" style="display:none"></p>
+        <div class="hidden md:flex flex-col items-center">
+          <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
+          <div id="preview2Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <div id="preview2Text" class="text-center space-y-3 break-words">
+              <h2 id="preview2Msg1" class="text-2xl font-bold" style="display:none"></h2>
+              <p id="preview2Msg2" class="text-lg" style="display:none"></p>
+              <div id="preview2Photo" style="display:none"></div>
+              <p id="preview2Ending" class="italic" style="display:none"></p>
+            </div>
           </div>
         </div>
+        </div>
       </div>
-    </div>
-    <!-- Generate URL -->
+      <!-- Generate URL -->
     <div class="bg-white rounded-2xl shadow-xl p-8 text-center">
       <button type="submit" class="w-full py-3 rounded-lg font-semibold" style="background-color:#c0dcca;color:#1f2937;" onmouseover="this.style.backgroundColor='#a8d0b5'" onmouseout="this.style.backgroundColor='#c0dcca'">Generate My Reveal URL</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -130,13 +130,13 @@
           </select>
         </div>
       </div>
-      </div>
-      <div class="hidden md:block mt-8">
-        <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
-        <div id="previewBackground" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-          <div id="previewText" class="text-center">
-            <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
-            <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
+        <div class="hidden md:flex flex-col items-center">
+          <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
+          <div id="previewBackground" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <div id="previewText" class="text-center break-words">
+              <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
+              <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
+            </div>
           </div>
         </div>
       </div>
@@ -154,10 +154,10 @@
           <p class="text-xs text-gray-500 mt-1">This text will appear in ALL CAPS.</p>
           <p class="text-xs font-medium mt-1" style="color:#c0dcca;">Note: This text will appear in ALL CAPS on your reveal page.</p>
         </div>
-        <div class="hidden md:block">
+        <div class="hidden md:flex flex-col items-center">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
-          <div id="preview1Background" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-            <h1 id="preview1Text" class="text-4xl font-bold" style="display:none"></h1>
+          <div id="preview1Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <h1 id="preview1Text" class="text-4xl font-bold break-words text-center" style="display:none"></h1>
           </div>
         </div>
       </div>
@@ -207,15 +207,15 @@
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
         </div>
-      </div>
-      <div class="hidden md:block mt-8">
-        <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
-        <div id="preview2Background" class="flex items-center justify-center rounded-lg w-24 mx-auto" style="aspect-ratio:9/16;background-color:#f3f3f3;">
-          <div id="preview2Text" class="text-center space-y-3">
-            <h2 id="preview2Msg1" class="text-2xl font-bold" style="display:none"></h2>
-            <p id="preview2Msg2" class="text-lg" style="display:none"></p>
-            <div id="preview2Photo" style="display:none"></div>
-            <p id="preview2Ending" class="italic" style="display:none"></p>
+        <div class="hidden md:flex flex-col items-center">
+          <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
+          <div id="preview2Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
+            <div id="preview2Text" class="text-center space-y-3 break-words">
+              <h2 id="preview2Msg1" class="text-2xl font-bold" style="display:none"></h2>
+              <p id="preview2Msg2" class="text-lg" style="display:none"></p>
+              <div id="preview2Photo" style="display:none"></div>
+              <p id="preview2Ending" class="italic" style="display:none"></p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- place section 1 preview in rightmost column
- center preview for main announcement and details sections
- allow preview boxes to grow with content

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68698839400c832f8a5bcf6580be7862