### PR TITLE
Move previews above inputs on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
           </select>
         </div>
       </div>
-        <div class="flex flex-col items-center">
+        <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
           <div id="previewBackground" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
             <div id="previewText" class="text-center break-words">
@@ -166,7 +166,7 @@
           <p class="text-xs text-gray-500 mt-1">This text will appear in ALL CAPS.</p>
           <p class="text-xs font-medium mt-1" style="color:#c0dcca;">Note: This text will appear in ALL CAPS on your reveal page.</p>
         </div>
-        <div class="flex flex-col items-center">
+        <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
           <div id="preview1Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
             <h1 id="preview1Text" class="text-4xl font-bold break-words text-center" style="display:none"></h1>
@@ -219,7 +219,7 @@
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
         </div>
-        <div class="flex flex-col items-center">
+        <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>
           <div id="preview2Background" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
             <div id="preview2Text" class="text-center space-y-3 break-words">


### PR DESCRIPTION
## Summary
- reorder preview components so they appear before the form questions on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6869d7d92f88832fa83e794aaa464c16