### PR TITLE
Rename sections to PAGE 1 and PAGE 2 correctly

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -43,7 +43,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section1">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">1</div>
-        <h2 class="text-2xl font-bold text-gray-800">Colors & Styling</h2>
+        <h2 class="text-2xl font-bold text-gray-800">Colors and Styling</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div class="md:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -145,7 +145,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section2">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">2</div>
-        <h2 class="text-2xl font-bold text-gray-800">Main Announcement</h2>
+        <h2 class="text-2xl font-bold text-gray-800">PAGE 1</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
@@ -166,7 +166,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section3">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">3</div>
-        <h2 class="text-2xl font-bold text-gray-800">Additional Details</h2>
+        <h2 class="text-2xl font-bold text-gray-800">PAGE 2</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div class="md:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-8">

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section1">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">1</div>
-        <h2 class="text-2xl font-bold text-gray-800">Colors & Styling</h2>
+        <h2 class="text-2xl font-bold text-gray-800">Colors and Styling</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div class="md:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -157,7 +157,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section2">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">2</div>
-        <h2 class="text-2xl font-bold text-gray-800">Main Announcement</h2>
+        <h2 class="text-2xl font-bold text-gray-800">PAGE 1</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
@@ -178,7 +178,7 @@
     <div class="bg-white rounded-2xl shadow-xl p-8" id="section3">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">3</div>
-        <h2 class="text-2xl font-bold text-gray-800">Additional Details</h2>
+        <h2 class="text-2xl font-bold text-gray-800">PAGE 2</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8">


### PR DESCRIPTION
## Summary
- restore original first section title
- label second section as `PAGE 1`
- label third section as `PAGE 2`

## Testing
- `grep -n "PAGE" index.html bigreveal`


------
https://chatgpt.com/codex/tasks/task_b_6869f97d5c28832fb13ba6bfa5ae04d8