### PR TITLE
Add per-text font options

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -115,8 +115,72 @@
           </div>
         </div>
         <div>
-          <label for="fontFamily" class="block text-sm font-semibold text-gray-700 mb-2">Font Style</label>
+          <label for="fontFamily" class="block text-sm font-semibold text-gray-700 mb-2">Default Font</label>
           <select id="fontFamily" class="w-full px-4 py-3 border border-gray-300 rounded-lg" required>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mb-2">Headline Font</label>
+          <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontSub" class="block text-sm font-semibold text-gray-700 mb-2">Sub Font</label>
+          <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontDate" class="block text-sm font-semibold text-gray-700 mb-2">Date Font</label>
+          <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mb-2">Signature Font</label>
+          <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -259,6 +323,10 @@ const els={
   outlinePicker:document.getElementById('outlinePicker'),
   outlineHex:document.getElementById('outlineHex'),
   fontFamily:document.getElementById('fontFamily'),
+  fontMain:document.getElementById('fontMain'),
+  fontSub:document.getElementById('fontSub'),
+  fontDate:document.getElementById('fontDate'),
+  fontFrom:document.getElementById('fontFrom'),
   mainHeadline:document.getElementById('mainHeadline'),
   message1:document.getElementById('message1'),
   message2:document.getElementById('message2'),
@@ -332,17 +400,21 @@ function updatePreview(){
     const text=getColorValue(els.textColor,els.textHex,'#000000');
     const outline=getColorValue(els.outlineColor,els.outlineHex,'transparent');
     const font=els.fontFamily.value;
+    const fontMain=els.fontMain.value||font;
+    const fontSub=els.fontSub.value||font;
+    const fontDate=els.fontDate.value||font;
+    const fontFrom=els.fontFrom.value||font;
 
     els.previewBackground.style.backgroundColor=bg;
     els.preview1Background.style.backgroundColor=bg;
     els.preview2Background.style.backgroundColor=bg;
 
-    applyTextStyles(els.previewMain,text,outline,font);
-    applyTextStyles(els.previewSub,text,outline,font);
-    applyTextStyles(els.preview1Text,text,outline,font);
-    applyTextStyles(els.preview2Msg1,text,outline,font);
-    applyTextStyles(els.preview2Msg2,text,outline,font);
-    applyTextStyles(els.preview2Ending,text,outline,font);
+    applyTextStyles(els.previewMain,text,outline,fontMain);
+    applyTextStyles(els.previewSub,text,outline,fontSub);
+    applyTextStyles(els.preview1Text,text,outline,fontMain);
+    applyTextStyles(els.preview2Msg1,text,outline,fontSub);
+    applyTextStyles(els.preview2Msg2,text,outline,fontDate);
+    applyTextStyles(els.preview2Ending,text,outline,fontFrom);
 
     const main=els.mainHeadline.value.trim().toUpperCase();
     els.previewMain.textContent=main||'Your Text Here';
@@ -373,7 +445,7 @@ function updatePreview(){
   },100);
 }
 
-['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
+['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','fontMain','fontSub','fontDate','fontFrom','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
   document.getElementById(id).addEventListener('input',updatePreview);
   document.getElementById(id).addEventListener('change',updatePreview);
 });
@@ -418,6 +490,10 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
     textColor:getColorValue(els.textColor,els.textHex,''),
     outlineColor:getColorValue(els.outlineColor,els.outlineHex,''),
     font:els.fontFamily.value,
+    fontMain:els.fontMain.value,
+    fontSub:els.fontSub.value,
+    fontDate:els.fontDate.value,
+    fontFrom:els.fontFrom.value,
     main:els.mainHeadline.value.trim(),
     sub:els.message1.value.trim(),
     date:els.message2.value.trim(),

--- a/index.html
+++ b/index.html
@@ -127,8 +127,72 @@
           </div>
         </div>
         <div>
-          <label for="fontFamily" class="block text-sm font-semibold text-gray-700 mb-2">Font Style</label>
+          <label for="fontFamily" class="block text-sm font-semibold text-gray-700 mb-2">Default Font</label>
           <select id="fontFamily" class="w-full px-4 py-3 border border-gray-300 rounded-lg" required>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mb-2">Headline Font</label>
+          <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontSub" class="block text-sm font-semibold text-gray-700 mb-2">Sub Font</label>
+          <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontDate" class="block text-sm font-semibold text-gray-700 mb-2">Date Font</label>
+          <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
+        </div>
+        <div>
+          <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mb-2">Signature Font</label>
+          <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -271,6 +335,10 @@ const els={
   outlinePicker:document.getElementById('outlinePicker'),
   outlineHex:document.getElementById('outlineHex'),
   fontFamily:document.getElementById('fontFamily'),
+  fontMain:document.getElementById('fontMain'),
+  fontSub:document.getElementById('fontSub'),
+  fontDate:document.getElementById('fontDate'),
+  fontFrom:document.getElementById('fontFrom'),
   mainHeadline:document.getElementById('mainHeadline'),
   message1:document.getElementById('message1'),
   message2:document.getElementById('message2'),
@@ -344,17 +412,21 @@ function updatePreview(){
     const text=getColorValue(els.textColor,els.textHex,'#000000');
     const outline=getColorValue(els.outlineColor,els.outlineHex,'transparent');
     const font=els.fontFamily.value;
+    const fontMain=els.fontMain.value||font;
+    const fontSub=els.fontSub.value||font;
+    const fontDate=els.fontDate.value||font;
+    const fontFrom=els.fontFrom.value||font;
 
     els.previewBackground.style.backgroundColor=bg;
     els.preview1Background.style.backgroundColor=bg;
     els.preview2Background.style.backgroundColor=bg;
 
-    applyTextStyles(els.previewMain,text,outline,font);
-    applyTextStyles(els.previewSub,text,outline,font);
-    applyTextStyles(els.preview1Text,text,outline,font);
-    applyTextStyles(els.preview2Msg1,text,outline,font);
-    applyTextStyles(els.preview2Msg2,text,outline,font);
-    applyTextStyles(els.preview2Ending,text,outline,font);
+    applyTextStyles(els.previewMain,text,outline,fontMain);
+    applyTextStyles(els.previewSub,text,outline,fontSub);
+    applyTextStyles(els.preview1Text,text,outline,fontMain);
+    applyTextStyles(els.preview2Msg1,text,outline,fontSub);
+    applyTextStyles(els.preview2Msg2,text,outline,fontDate);
+    applyTextStyles(els.preview2Ending,text,outline,fontFrom);
 
     const main=els.mainHeadline.value.trim().toUpperCase();
     els.previewMain.textContent=main||'Your Text Here';
@@ -385,7 +457,7 @@ function updatePreview(){
   },100);
 }
 
-['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
+['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','fontMain','fontSub','fontDate','fontFrom','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
   document.getElementById(id).addEventListener('input',updatePreview);
   document.getElementById(id).addEventListener('change',updatePreview);
 });
@@ -447,6 +519,10 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
     textColor:getColorValue(els.textColor,els.textHex,''),
     outlineColor:getColorValue(els.outlineColor,els.outlineHex,''),
     font:els.fontFamily.value,
+    fontMain:els.fontMain.value,
+    fontSub:els.fontSub.value,
+    fontDate:els.fontDate.value,
+    fontFrom:els.fontFrom.value,
     main:els.mainHeadline.value.trim(),
     sub:els.message1.value.trim(),
     date:els.message2.value.trim(),


### PR DESCRIPTION
## Summary
- allow specifying fonts for each text block
- add new form fields and preview updates for fonts
- include new URL parameters when generating the link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686aa51f335c832fa47e79939c32bb04