### PR TITLE
Allow custom fonts per message

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,70 +141,6 @@
             <option value="Sacramento">Sacramento</option>
           </select>
         </div>
-        <div>
-          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mb-2">Headline Font</label>
-          <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
-            <option value="Poppins">Poppins</option>
-            <option value="Playfair Display">Playfair Display</option>
-            <option value="Dancing Script">Dancing Script</option>
-            <option value="Montserrat">Montserrat</option>
-            <option value="Great Vibes">Great Vibes</option>
-            <option value="Roboto">Roboto</option>
-            <option value="Lora">Lora</option>
-            <option value="Pacifico">Pacifico</option>
-            <option value="Crimson Text">Crimson Text</option>
-            <option value="Sacramento">Sacramento</option>
-          </select>
-        </div>
-        <div>
-          <label for="fontSub" class="block text-sm font-semibold text-gray-700 mb-2">Sub Font</label>
-          <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
-            <option value="Poppins">Poppins</option>
-            <option value="Playfair Display">Playfair Display</option>
-            <option value="Dancing Script">Dancing Script</option>
-            <option value="Montserrat">Montserrat</option>
-            <option value="Great Vibes">Great Vibes</option>
-            <option value="Roboto">Roboto</option>
-            <option value="Lora">Lora</option>
-            <option value="Pacifico">Pacifico</option>
-            <option value="Crimson Text">Crimson Text</option>
-            <option value="Sacramento">Sacramento</option>
-          </select>
-        </div>
-        <div>
-          <label for="fontDate" class="block text-sm font-semibold text-gray-700 mb-2">Date Font</label>
-          <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
-            <option value="Poppins">Poppins</option>
-            <option value="Playfair Display">Playfair Display</option>
-            <option value="Dancing Script">Dancing Script</option>
-            <option value="Montserrat">Montserrat</option>
-            <option value="Great Vibes">Great Vibes</option>
-            <option value="Roboto">Roboto</option>
-            <option value="Lora">Lora</option>
-            <option value="Pacifico">Pacifico</option>
-            <option value="Crimson Text">Crimson Text</option>
-            <option value="Sacramento">Sacramento</option>
-          </select>
-        </div>
-        <div>
-          <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mb-2">Signature Font</label>
-          <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
-            <option value="Poppins">Poppins</option>
-            <option value="Playfair Display">Playfair Display</option>
-            <option value="Dancing Script">Dancing Script</option>
-            <option value="Montserrat">Montserrat</option>
-            <option value="Great Vibes">Great Vibes</option>
-            <option value="Roboto">Roboto</option>
-            <option value="Lora">Lora</option>
-            <option value="Pacifico">Pacifico</option>
-            <option value="Crimson Text">Crimson Text</option>
-            <option value="Sacramento">Sacramento</option>
-          </select>
-        </div>
       </div>
         <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
@@ -229,6 +165,20 @@
           <input id="mainHeadline" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="We're Expecting!" required />
           <p class="text-xs text-gray-500 mt-1">This text will appear in ALL CAPS.</p>
           <p class="text-xs font-medium mt-1" style="color:#c0dcca;">Note: This text will appear in ALL CAPS on your reveal page.</p>
+          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Main Headline Font</label>
+          <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+            <option value="">Same as default</option>
+            <option value="Poppins">Poppins</option>
+            <option value="Playfair Display">Playfair Display</option>
+            <option value="Dancing Script">Dancing Script</option>
+            <option value="Montserrat">Montserrat</option>
+            <option value="Great Vibes">Great Vibes</option>
+            <option value="Roboto">Roboto</option>
+            <option value="Lora">Lora</option>
+            <option value="Pacifico">Pacifico</option>
+            <option value="Crimson Text">Crimson Text</option>
+            <option value="Sacramento">Sacramento</option>
+          </select>
         </div>
         <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
@@ -249,10 +199,38 @@
         <div>
           <label for="message1" class="block text-sm font-semibold text-gray-700 mb-2">Message 1</label>
           <input id="message1" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Baby Johnson" required />
+            <label for="fontSub" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 1 Font</label>
+            <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as default</option>
+              <option value="Poppins">Poppins</option>
+              <option value="Playfair Display">Playfair Display</option>
+              <option value="Dancing Script">Dancing Script</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Great Vibes">Great Vibes</option>
+              <option value="Roboto">Roboto</option>
+              <option value="Lora">Lora</option>
+              <option value="Pacifico">Pacifico</option>
+              <option value="Crimson Text">Crimson Text</option>
+              <option value="Sacramento">Sacramento</option>
+            </select>
         </div>
         <div>
           <label for="message2" class="block text-sm font-semibold text-gray-700 mb-2">Message 2 (optional)</label>
           <input id="message2" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Coming soon!" />
+            <label for="fontDate" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 2 Font</label>
+            <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as default</option>
+              <option value="Poppins">Poppins</option>
+              <option value="Playfair Display">Playfair Display</option>
+              <option value="Dancing Script">Dancing Script</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Great Vibes">Great Vibes</option>
+              <option value="Roboto">Roboto</option>
+              <option value="Lora">Lora</option>
+              <option value="Pacifico">Pacifico</option>
+              <option value="Crimson Text">Crimson Text</option>
+              <option value="Sacramento">Sacramento</option>
+            </select>
         </div>
         <div class="md:col-span-2">
           <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">
@@ -282,6 +260,20 @@
         <div class="md:col-span-2">
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
+            <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Final Message Font</label>
+            <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as default</option>
+              <option value="Poppins">Poppins</option>
+              <option value="Playfair Display">Playfair Display</option>
+              <option value="Dancing Script">Dancing Script</option>
+              <option value="Montserrat">Montserrat</option>
+              <option value="Great Vibes">Great Vibes</option>
+              <option value="Roboto">Roboto</option>
+              <option value="Lora">Lora</option>
+              <option value="Pacifico">Pacifico</option>
+              <option value="Crimson Text">Crimson Text</option>
+              <option value="Sacramento">Sacramento</option>
+            </select>
         </div>
       </div>
       <div class="flex flex-col items-center order-first md:order-none">


### PR DESCRIPTION
## Summary
- remove message font pickers from style section
- add font dropdowns next to each message field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ad7197990832f9042412c05d2237c