### PR TITLE
Add per-line text styling controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,21 @@
             <option value="Crimson Text">Crimson Text</option>
             <option value="Sacramento">Sacramento</option>
           </select>
+          <div class="grid grid-cols-2 gap-2 mt-4">
+            <div>
+              <label for="mainTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
+              <input id="mainTextColor" type="color" class="w-full h-10 border rounded" value="#000000" />
+            </div>
+            <div>
+              <label for="mainOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
+              <input id="mainOutlineColor" type="color" class="w-full h-10 border rounded" value="#ffffff" />
+            </div>
+          </div>
+          <div class="flex items-center space-x-4 mt-2">
+            <label class="text-xs"><input id="mainBold" type="checkbox" class="mr-1" />Bold</label>
+            <label class="text-xs"><input id="mainItalic" type="checkbox" class="mr-1" />Italic</label>
+            <label class="text-xs"><input id="mainCaps" type="checkbox" class="mr-1" checked />Caps</label>
+          </div>
         </div>
         <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 1</h3>
@@ -213,6 +228,21 @@
               <option value="Crimson Text">Crimson Text</option>
               <option value="Sacramento">Sacramento</option>
             </select>
+            <div class="grid grid-cols-2 gap-2 mt-4">
+              <div>
+                <label for="subTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
+                <input id="subTextColor" type="color" class="w-full h-10 border rounded" value="#000000" />
+              </div>
+              <div>
+                <label for="subOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
+                <input id="subOutlineColor" type="color" class="w-full h-10 border rounded" value="#ffffff" />
+              </div>
+            </div>
+            <div class="flex items-center space-x-4 mt-2">
+              <label class="text-xs"><input id="subBold" type="checkbox" class="mr-1" />Bold</label>
+              <label class="text-xs"><input id="subItalic" type="checkbox" class="mr-1" />Italic</label>
+              <label class="text-xs"><input id="subCaps" type="checkbox" class="mr-1" checked />Caps</label>
+            </div>
         </div>
         <div>
           <label for="message2" class="block text-sm font-semibold text-gray-700 mb-2">Message 2 (optional)</label>
@@ -231,6 +261,21 @@
               <option value="Crimson Text">Crimson Text</option>
               <option value="Sacramento">Sacramento</option>
             </select>
+            <div class="grid grid-cols-2 gap-2 mt-4">
+              <div>
+                <label for="dateTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
+                <input id="dateTextColor" type="color" class="w-full h-10 border rounded" value="#000000" />
+              </div>
+              <div>
+                <label for="dateOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
+                <input id="dateOutlineColor" type="color" class="w-full h-10 border rounded" value="#ffffff" />
+              </div>
+            </div>
+            <div class="flex items-center space-x-4 mt-2">
+              <label class="text-xs"><input id="dateBold" type="checkbox" class="mr-1" />Bold</label>
+              <label class="text-xs"><input id="dateItalic" type="checkbox" class="mr-1" />Italic</label>
+              <label class="text-xs"><input id="dateCaps" type="checkbox" class="mr-1" />Caps</label>
+            </div>
         </div>
         <div class="md:col-span-2">
           <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">
@@ -274,6 +319,21 @@
               <option value="Crimson Text">Crimson Text</option>
               <option value="Sacramento">Sacramento</option>
             </select>
+            <div class="grid grid-cols-2 gap-2 mt-4">
+              <div>
+                <label for="fromTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
+                <input id="fromTextColor" type="color" class="w-full h-10 border rounded" value="#000000" />
+              </div>
+              <div>
+                <label for="fromOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
+                <input id="fromOutlineColor" type="color" class="w-full h-10 border rounded" value="#ffffff" />
+              </div>
+            </div>
+            <div class="flex items-center space-x-4 mt-2">
+              <label class="text-xs"><input id="fromBold" type="checkbox" class="mr-1" />Bold</label>
+              <label class="text-xs"><input id="fromItalic" type="checkbox" class="mr-1" />Italic</label>
+              <label class="text-xs"><input id="fromCaps" type="checkbox" class="mr-1" />Caps</label>
+            </div>
         </div>
       </div>
       <div class="flex flex-col items-center order-first md:order-none">
@@ -331,6 +391,26 @@ const els={
   fontSub:document.getElementById('fontSub'),
   fontDate:document.getElementById('fontDate'),
   fontFrom:document.getElementById('fontFrom'),
+  mainTextColor:document.getElementById('mainTextColor'),
+  mainOutlineColor:document.getElementById('mainOutlineColor'),
+  mainBold:document.getElementById('mainBold'),
+  mainItalic:document.getElementById('mainItalic'),
+  mainCaps:document.getElementById('mainCaps'),
+  subTextColor:document.getElementById('subTextColor'),
+  subOutlineColor:document.getElementById('subOutlineColor'),
+  subBold:document.getElementById('subBold'),
+  subItalic:document.getElementById('subItalic'),
+  subCaps:document.getElementById('subCaps'),
+  dateTextColor:document.getElementById('dateTextColor'),
+  dateOutlineColor:document.getElementById('dateOutlineColor'),
+  dateBold:document.getElementById('dateBold'),
+  dateItalic:document.getElementById('dateItalic'),
+  dateCaps:document.getElementById('dateCaps'),
+  fromTextColor:document.getElementById('fromTextColor'),
+  fromOutlineColor:document.getElementById('fromOutlineColor'),
+  fromBold:document.getElementById('fromBold'),
+  fromItalic:document.getElementById('fromItalic'),
+  fromCaps:document.getElementById('fromCaps'),
   mainHeadline:document.getElementById('mainHeadline'),
   message1:document.getElementById('message1'),
   message2:document.getElementById('message2'),
@@ -375,10 +455,12 @@ function syncColorInputs(picker,hex,val){
   }
 }
 
-function applyTextStyles(el,color,outline,font){
+function applyTextStyles(el,color,outline,font,bold,italic){
   if(!el) return;
   el.style.color=color;
   el.style.fontFamily=`'${font}', sans-serif`;
+  el.style.fontWeight=bold?'bold':'normal';
+  el.style.fontStyle=italic?'italic':'normal';
   if(outline==='transparent'){
     el.style.textShadow='none';
     el.style.webkitTextStroke='0';
@@ -409,28 +491,53 @@ function updatePreview(){
     const fontDate=els.fontDate.value||font;
     const fontFrom=els.fontFrom.value||font;
 
+    const mainColor=els.mainTextColor.value||text;
+    const mainOutline=els.mainOutlineColor.value||outline;
+    const subColor=els.subTextColor.value||text;
+    const subOutline=els.subOutlineColor.value||outline;
+    const dateColor=els.dateTextColor.value||text;
+    const dateOutline=els.dateOutlineColor.value||outline;
+    const fromColor=els.fromTextColor.value||text;
+    const fromOutline=els.fromOutlineColor.value||outline;
+
+    const mainBold=els.mainBold.checked;
+    const mainItalic=els.mainItalic.checked;
+    const subBold=els.subBold.checked;
+    const subItalic=els.subItalic.checked;
+    const dateBold=els.dateBold.checked;
+    const dateItalic=els.dateItalic.checked;
+    const fromBold=els.fromBold.checked;
+    const fromItalic=els.fromItalic.checked;
+    const mainCaps=els.mainCaps.checked;
+    const subCaps=els.subCaps.checked;
+    const dateCaps=els.dateCaps.checked;
+    const fromCaps=els.fromCaps.checked;
+
     els.previewBackground.style.backgroundColor=bg;
     els.preview1Background.style.backgroundColor=bg;
     els.preview2Background.style.backgroundColor=bg;
 
-    applyTextStyles(els.previewMain,text,outline,fontMain);
-    applyTextStyles(els.previewSub,text,outline,fontSub);
-    applyTextStyles(els.preview1Text,text,outline,fontMain);
-    applyTextStyles(els.preview2Msg1,text,outline,fontSub);
-    applyTextStyles(els.preview2Msg2,text,outline,fontDate);
-    applyTextStyles(els.preview2Ending,text,outline,fontFrom);
+    applyTextStyles(els.previewMain,mainColor,mainOutline,fontMain,mainBold,mainItalic);
+    applyTextStyles(els.previewSub,subColor,subOutline,fontSub,subBold,subItalic);
+    applyTextStyles(els.preview1Text,mainColor,mainOutline,fontMain,mainBold,mainItalic);
+    applyTextStyles(els.preview2Msg1,subColor,subOutline,fontSub,subBold,subItalic);
+    applyTextStyles(els.preview2Msg2,dateColor,dateOutline,fontDate,dateBold,dateItalic);
+    applyTextStyles(els.preview2Ending,fromColor,fromOutline,fontFrom,fromBold,fromItalic);
 
-    const main=els.mainHeadline.value.trim().toUpperCase();
+    const mainRaw=els.mainHeadline.value.trim();
+    const main=mainCaps?mainRaw.toUpperCase():mainRaw;
     els.previewMain.textContent=main||'Your Text Here';
     els.preview1Text.textContent=main;
     els.preview1Text.style.display=main?'block':'none';
 
-    const msg1=els.message1.value.trim().toUpperCase();
+    const msg1Raw=els.message1.value.trim();
+    const msg1=subCaps?msg1Raw.toUpperCase():msg1Raw;
     els.previewSub.textContent=msg1||'This will be the style for the reveal';
     els.preview2Msg1.textContent=msg1;
     els.preview2Msg1.style.display=msg1?'block':'none';
 
-    const msg2=els.message2.value.trim();
+    const msg2Raw=els.message2.value.trim();
+    const msg2=dateCaps?msg2Raw.toUpperCase():msg2Raw;
     els.preview2Msg2.textContent=msg2;
     els.preview2Msg2.style.display=msg2?'block':'none';
 
@@ -443,13 +550,14 @@ function updatePreview(){
       els.preview2Photo.style.display='none';
     }
 
-    const end=els.ending.value.trim();
+    const endRaw=els.ending.value.trim();
+    const end=fromCaps?endRaw.toUpperCase():endRaw;
     els.preview2Ending.textContent=end;
     els.preview2Ending.style.display=end?'block':'none';
   },100);
 }
 
-['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','fontMain','fontSub','fontDate','fontFrom','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
+['backgroundTheme','backgroundPicker','backgroundHex','textColor','textPicker','textHex','outlineColor','outlinePicker','outlineHex','fontFamily','fontMain','fontSub','fontDate','fontFrom','mainTextColor','mainOutlineColor','mainBold','mainItalic','mainCaps','subTextColor','subOutlineColor','subBold','subItalic','subCaps','dateTextColor','dateOutlineColor','dateBold','dateItalic','dateCaps','fromTextColor','fromOutlineColor','fromBold','fromItalic','fromCaps','mainHeadline','message1','message2','photo','ending'].forEach(id=>{
   document.getElementById(id).addEventListener('input',updatePreview);
   document.getElementById(id).addEventListener('change',updatePreview);
 });
@@ -519,7 +627,27 @@ document.getElementById('revealForm').addEventListener('submit',async e=>{
     sub:els.message1.value.trim(),
     date:els.message2.value.trim(),
     photo:els.photo.value.trim(),
-    from:els.ending.value.trim()
+    from:els.ending.value.trim(),
+    mainTextColor:els.mainTextColor.value,
+    mainOutlineColor:els.mainOutlineColor.value,
+    subTextColor:els.subTextColor.value,
+    subOutlineColor:els.subOutlineColor.value,
+    dateTextColor:els.dateTextColor.value,
+    dateOutlineColor:els.dateOutlineColor.value,
+    fromTextColor:els.fromTextColor.value,
+    fromOutlineColor:els.fromOutlineColor.value,
+    mainBold:els.mainBold.checked?1:0,
+    mainItalic:els.mainItalic.checked?1:0,
+    mainCaps:els.mainCaps.checked?1:0,
+    subBold:els.subBold.checked?1:0,
+    subItalic:els.subItalic.checked?1:0,
+    subCaps:els.subCaps.checked?1:0,
+    dateBold:els.dateBold.checked?1:0,
+    dateItalic:els.dateItalic.checked?1:0,
+    dateCaps:els.dateCaps.checked?1:0,
+    fromBold:els.fromBold.checked?1:0,
+    fromItalic:els.fromItalic.checked?1:0,
+    fromCaps:els.fromCaps.checked?1:0
   });
   const base='https://bigreveal.joyjotstudio.store/';
   let full=`${base}?${params.toString()}`;


### PR DESCRIPTION
## Summary
- allow customizing text color, outline, and style for each line
- preview updates show the chosen options
- send the new parameters when generating URLs

## Testing
- `npm --version`
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_686adcaab7f4832f95632c1eb48239e2