### PR TITLE
Refactor message fields into collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
           <input id="mainHeadline" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="We're Expecting!" required />
           <label for="fontMain" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Main Headline Font</label>
           <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
+            <option value="">Same as Default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -167,12 +167,14 @@
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div class="space-y-8">
-        <div>
+        <details open class="mb-4">
+          <summary class="font-semibold text-lg cursor-pointer">Message 1</summary>
+          <div class="mt-4 space-y-4">
           <label for="message1" class="block text-sm font-semibold text-gray-700 mb-2">Message 1</label>
           <input id="message1" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Baby Johnson" required />
-            <label for="fontSub" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 1 Font</label>
-            <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as default</option>
+          <label for="fontSub" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 1 Font</label>
+          <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>
@@ -188,7 +190,7 @@
               <div>
                 <label for="subTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
                 <select id="subTextColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
                   <option value="#374151">Dark Gray</option>
@@ -211,7 +213,7 @@
               <div>
                 <label for="subOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
                 <select id="subOutlineColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="transparent">None</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
@@ -238,13 +240,17 @@
               <label class="text-xs"><input id="subItalic" type="checkbox" class="mr-1" />Italic</label>
               <label class="text-xs"><input id="subCaps" type="checkbox" class="mr-1" checked />Caps</label>
             </div>
-        </div>
-        <div>
+          </div>
+        </details>
+        <hr class="my-6">
+        <details open class="mb-4">
+          <summary class="font-semibold text-lg cursor-pointer">Message 2 (optional)</summary>
+          <div class="mt-4 space-y-4">
           <label for="message2" class="block text-sm font-semibold text-gray-700 mb-2">Message 2 (optional)</label>
           <input id="message2" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Coming soon!" />
-            <label for="fontDate" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 2 Font</label>
-            <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as default</option>
+          <label for="fontDate" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 2 Font</label>
+          <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>
@@ -260,7 +266,7 @@
               <div>
                 <label for="dateTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
                 <select id="dateTextColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
                   <option value="#374151">Dark Gray</option>
@@ -283,7 +289,7 @@
               <div>
                 <label for="dateOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
                 <select id="dateOutlineColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="transparent">None</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
@@ -310,13 +316,17 @@
               <label class="text-xs"><input id="dateItalic" type="checkbox" class="mr-1" />Italic</label>
               <label class="text-xs"><input id="dateCaps" type="checkbox" class="mr-1" />Caps</label>
             </div>
-        </div>
-        <div>
+          </div>
+        </details>
+        <hr class="my-6">
+        <details open class="mb-4">
+          <summary class="font-semibold text-lg cursor-pointer">Ending Message (optional)</summary>
+          <div class="mt-4 space-y-4">
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
-            <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Final Message Font</label>
-            <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as default</option>
+          <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Final Message Font</label>
+          <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
+              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>
@@ -332,7 +342,7 @@
               <div>
                 <label for="fromTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
                 <select id="fromTextColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
                   <option value="#374151">Dark Gray</option>
@@ -355,7 +365,7 @@
               <div>
                 <label for="fromOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
                 <select id="fromOutlineColor" class="w-full px-4 py-2 border border-gray-300 rounded-lg mb-2">
-                  <option value="">Use default</option>
+                  <option value="">Use Default</option>
                   <option value="transparent">None</option>
                   <option value="#000000">Black</option>
                   <option value="#ffffff">White</option>
@@ -382,8 +392,12 @@
               <label class="text-xs"><input id="fromItalic" type="checkbox" class="mr-1" />Italic</label>
           <label class="text-xs"><input id="fromCaps" type="checkbox" class="mr-1" />Caps</label>
             </div>
-        </div>
-        <div>
+          </div>
+        </details>
+        <hr class="my-6">
+        <details open class="mb-4">
+          <summary class="font-semibold text-lg cursor-pointer">Photo Upload (optional)</summary>
+          <div class="mt-4 space-y-4">
           <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">
             Photo URL <span class="text-gray-400">(optional)</span>
             <span class="inline-block relative ml-1 group cursor-help">
@@ -407,7 +421,8 @@
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 transition-all"
           >
           <p class="text-xs text-gray-500 mt-1">Upload to Imgur, Postimg, etc., and paste the direct link here.</p>
-        </div>
+          </div>
+        </details>
       </div>
       <div class="flex flex-col items-center order-first md:order-none">
         <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview — Page 2</h3>


### PR DESCRIPTION
## Summary
- add `<details>` wrappers for Message 1, Message 2, Ending Message and Photo fields
- insert `<hr>` between the new sections for easier scanning
- standardize dropdown capitalization to Title Case

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ae85cf0b8832fbb3660c3079eeb1b