### PR TITLE
Tweak preview and details defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,8 @@
       </div>
         <div class="flex flex-col items-center order-first md:order-none">
           <h3 class="text-lg font-semibold text-gray-700 mb-2">Live Preview</h3>
-          <div id="previewBackground" class="flex items-center justify-center rounded-lg w-fit max-w-[8rem] p-2" style="background-color:#f3f3f3;">
-            <div id="previewText" class="text-center break-words">
+          <div id="previewBackground" class="flex items-center justify-center rounded-lg w-32 h-20" style="background-color:#f3f3f3;">
+            <div id="previewText" class="text-center break-words hidden">
               <h1 id="previewMain" class="text-3xl font-bold">Your Text Here</h1>
               <p id="previewSub" class="text-lg">This will be the style for the reveal</p>
             </div>
@@ -167,7 +167,7 @@
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div class="space-y-8">
-        <details open class="mb-4">
+        <details class="mb-4">
           <summary class="font-semibold text-lg cursor-pointer">Message 1</summary>
           <div class="mt-4 space-y-4">
           <label for="message1" class="block text-sm font-semibold text-gray-700 mb-2">Message 1</label>
@@ -243,7 +243,7 @@
           </div>
         </details>
         <hr class="my-6">
-        <details open class="mb-4">
+        <details class="mb-4">
           <summary class="font-semibold text-lg cursor-pointer">Message 2 (optional)</summary>
           <div class="mt-4 space-y-4">
           <label for="message2" class="block text-sm font-semibold text-gray-700 mb-2">Message 2 (optional)</label>
@@ -319,7 +319,7 @@
           </div>
         </details>
         <hr class="my-6">
-        <details open class="mb-4">
+        <details class="mb-4">
           <summary class="font-semibold text-lg cursor-pointer">Ending Message (optional)</summary>
           <div class="mt-4 space-y-4">
           <label for="ending" class="block text-sm font-semibold text-gray-700 mb-2">Ending Message (optional)</label>
@@ -395,7 +395,7 @@
           </div>
         </details>
         <hr class="my-6">
-        <details open class="mb-4">
+        <details class="mb-4">
           <summary class="font-semibold text-lg cursor-pointer">Photo Upload (optional)</summary>
           <div class="mt-4 space-y-4">
           <label for="photo" class="block text-sm font-semibold text-gray-700 mb-2">


### PR DESCRIPTION
## Summary
- hide preview text in background section and size preview box
- collapse optional detail sections by default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686aeb96795c832f9b9fc276c6950d68