### PR TITLE
Remove 'Same as Default' dropdown options

### DIFF
--- a/bigreveal
+++ b/bigreveal
@@ -132,7 +132,6 @@
         <div>
           <label for="fontMain" class="block text-sm font-semibold text-gray-700 mb-2">Headline Font</label>
           <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -148,7 +147,6 @@
         <div>
           <label for="fontSub" class="block text-sm font-semibold text-gray-700 mb-2">Sub Font</label>
           <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -164,7 +162,6 @@
         <div>
           <label for="fontDate" class="block text-sm font-semibold text-gray-700 mb-2">Date Font</label>
           <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -180,7 +177,6 @@
         <div>
           <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mb-2">Signature Font</label>
           <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,6 @@
           <input id="mainHeadline" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="We're Expecting!" required />
           <label for="fontMain" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Main Headline Font</label>
           <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-            <option value="">Same as Default</option>
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
             <option value="Dancing Script">Dancing Script</option>
@@ -174,7 +173,6 @@
           <input id="message1" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Baby Johnson" required />
           <label for="fontSub" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 1 Font</label>
           <select id="fontSub" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>
@@ -250,7 +248,6 @@
           <input id="message2" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Coming soon!" />
           <label for="fontDate" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Message 2 Font</label>
           <select id="fontDate" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>
@@ -326,7 +323,6 @@
           <input id="ending" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="Love, The Johnsons" />
           <label for="fontFrom" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Final Message Font</label>
           <select id="fontFrom" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
-              <option value="">Same as Default</option>
               <option value="Poppins">Poppins</option>
               <option value="Playfair Display">Playfair Display</option>
               <option value="Dancing Script">Dancing Script</option>


### PR DESCRIPTION
## Summary
- remove `Same as Default` options from dropdowns in `index.html`
- remove `Same as default` options from dropdowns in `bigreveal`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686aed5bdb50832fb1e7b3905c5c25cd