### PR TITLE
Refactor generator to wizard steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
 <style>
   body { font-family: 'Poppins', sans-serif; }
   input:focus, select:focus { outline: none; box-shadow: 0 0 0 3px rgba(255,184,141,0.2); border-color:#ffb88d; }
+  .step { display:none; }
+  .step.active { display:block; }
   .confetti {
     position: fixed;
     width: 8px;
@@ -51,8 +53,9 @@
     <p class="text-gray-600">Create your personalized reveal page and get a shareable link!</p>
   </div>
   <form id="revealForm" class="space-y-8">
+    <div id="progress" class="font-semibold text-center mb-4"></div>
     <!-- Section 1 -->
-    <div class="bg-white rounded-2xl shadow-xl p-8" id="section1">
+    <div class="step bg-white rounded-2xl shadow-xl p-8" id="section1">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">A</div>
         <h2 class="text-2xl font-bold text-gray-800">Background Color</h2>
@@ -91,9 +94,12 @@
           </div>
         </div>
       </div>
+      <div class="flex justify-end mt-4">
+        <button type="button" class="next px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Next</button>
+      </div>
     </div>
     <!-- Section 2 -->
-    <div class="bg-white rounded-2xl shadow-xl p-8" id="section2">
+    <div class="step bg-white rounded-2xl shadow-xl p-8" id="section2">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">B</div>
         <h2 class="text-2xl font-bold text-gray-800">Page 1</h2>
@@ -177,9 +183,13 @@
           </div>
         </div>
       </div>
-    </div>
-    <!-- Section 3 -->
-    <div class="bg-white rounded-2xl shadow-xl p-8" id="section3">
+      </div>
+      <div class="flex justify-between mt-4">
+        <button type="button" class="back px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Back</button>
+        <button type="button" class="next px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Next</button>
+      </div>
+      <!-- Section 3 -->
+    <div class="step bg-white rounded-2xl shadow-xl p-8" id="section3">
       <div class="flex items-center mb-6">
         <div class="rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3" style="background-color:#ffb88d;color:#1f2937;">C</div>
         <h2 class="text-2xl font-bold text-gray-800">Page 2</h2>
@@ -452,9 +462,16 @@
         </div>
       </div>
     </div>
+    <div class="flex justify-between mt-4">
+      <button type="button" class="back px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Back</button>
+      <button type="button" class="next px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Next</button>
+    </div>
     <!-- Generate URL -->
-    <div class="bg-white rounded-2xl shadow-xl p-8 text-center">
+    <div class="step bg-white rounded-2xl shadow-xl p-8 text-center" id="generateStep">
       <button id="generateBtn" type="button" class="w-full py-3 rounded-lg font-semibold bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Generate My Reveal URL</button>
+      <div class="flex justify-start mt-4">
+        <button type="button" class="back px-4 py-2 rounded bg-[#c0dcca] text-gray-800 hover:bg-[#a8d0b5]">Back</button>
+      </div>
     </div>
   </form>
   <div id="urlResult" class="hidden bg-white rounded-2xl shadow-xl p-8 text-center">
@@ -816,6 +833,19 @@ updatePreview();
 const generateBtn=document.getElementById('generateBtn');
 const defaultText=generateBtn.textContent;
 const statusEl=document.getElementById('statusMsg');
+
+// ----- Wizard Step Navigation -----
+const steps=document.querySelectorAll('#revealForm .step');
+const progressEl=document.getElementById('progress');
+let currentStep=0;
+function showStep(i){
+  steps.forEach((s,idx)=>s.classList.toggle('active',idx===i));
+  progressEl.textContent=`Step ${i+1} of ${steps.length}`;
+  generateBtn.disabled=i!==steps.length-1;
+}
+document.querySelectorAll('#revealForm .next').forEach(b=>b.addEventListener('click',()=>{if(currentStep<steps.length-1){currentStep++;showStep(currentStep);}}));
+document.querySelectorAll('#revealForm .back').forEach(b=>b.addEventListener('click',()=>{if(currentStep>0){currentStep--;showStep(currentStep);}}));
+showStep(0);
 
 function showConfettiAt(x,y){
   const colors=['#ffc700','#ff0000','#2ecc40','#0074D9','#B10DC9'];


### PR DESCRIPTION
## Summary
- turn main form into a multi‑step wizard
- add basic `.step` CSS and progress indicator
- add navigation buttons and JS to handle back/next logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6878166b28e4832fa01d7c8cd9c741c4