### PR TITLE
Add simple 8‑step wizard form

### DIFF
--- a/wizard.html
+++ b/wizard.html
@@ -3,189 +3,207 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Reveal Wizard</title>
+<title>Announcement Wizard</title>
 <style>
-  body { font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 1rem; }
-  .step { display: none; }
-  .step.active { display: block; }
-  .actions { margin-top: 1rem; }
-  .progress { font-weight: bold; margin-bottom: 1rem; }
+  body{font-family:sans-serif;max-width:600px;margin:0 auto;padding:1rem;}
+  .step{display:none;}
+  .step.active{display:block;}
+  .nav{margin-top:1rem;}
+  label{display:block;margin:0.5rem 0;}
+  progress{width:100%;}
 </style>
 </head>
 <body>
-<h1>Big Reveal Wizard</h1>
-<form id="wizardForm">
-<p class="progress">Step <span id="stepNum">1</span> of <span id="stepTotal">7</span></p>
-<div class="step active" data-step="1">
-  <h2>Main Message</h2>
-  <p>What's your big reveal? Example: "It's a Girl!"</p>
-  <input id="main" name="main" required>
-  <div class="actions">
-    <button type="button" id="nextBtn1">Next</button>
+<h1>Create Your Announcement</h1>
+<form id="wizard">
+  <div id="progressText">Step 1 of 8</div>
+  <progress id="progressBar" value="1" max="8"></progress>
+
+  <div class="step active" data-step="1">
+    <h2>Background Color</h2>
+    <p>What background color do you want for your announcement?</p>
+    <input type="color" id="color" name="color" value="#f3ddbb">
+    <div class="nav"><button type="button" class="next">Next</button></div>
   </div>
-</div>
-<div class="step" data-step="2">
-  <h2>Include a Photo?</h2>
-  <label><input type="radio" name="hasPhoto" value="yes"> Yes</label>
-  <label><input type="radio" name="hasPhoto" value="no" checked> No</label>
-  <div id="photoField" style="display:none; margin-top:0.5rem;">
-    <label>Photo URL <input type="url" id="photo" name="photo"></label>
+
+  <div class="step" data-step="2">
+    <h2>First Reveal Message</h2>
+    <p>What's the first message that should appear after the reels spin?</p>
+    <input type="text" id="main" name="main">
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
   </div>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="button" class="next">Next</button>
-  </div>
-</div>
-<div class="step" data-step="3">
-  <h2>Include a Due Date or Detail?</h2>
-  <label><input type="radio" name="hasDate" value="yes"> Yes</label>
-  <label><input type="radio" name="hasDate" value="no" checked> No</label>
-  <div id="dateField" style="display:none; margin-top:0.5rem;">
-    <label>Detail Line <input type="text" id="date" name="date"></label>
-  </div>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="button" class="next">Next</button>
-  </div>
-</div>
-<div class="step" data-step="4">
-  <h2>Add a Signature?</h2>
-  <label><input type="radio" name="hasFrom" value="yes"> Yes</label>
-  <label><input type="radio" name="hasFrom" value="no" checked> No</label>
-  <div id="fromField" style="display:none; margin-top:0.5rem;">
-    <label>Signature <input type="text" id="from" name="from"></label>
-  </div>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="button" class="next">Next</button>
-  </div>
-</div>
-<div class="step" data-step="5">
-  <h2>Pick a Background Color</h2>
-  <label><input type="radio" name="color" value="beige" checked> Beige</label>
-  <label><input type="radio" name="color" value="pink"> Pink</label>
-  <label><input type="radio" name="color" value="blue"> Blue</label>
-  <label><input type="radio" name="color" value="custom"> Custom</label>
-  <div id="customColor" style="display:none; margin-top:0.5rem;">
-    <input type="text" id="colorHex" placeholder="#abcdef">
-  </div>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="button" class="next">Next</button>
-  </div>
-</div>
-<div class="step" data-step="6">
-  <h2>Advanced Options</h2>
-  <details>
-    <summary>Show text and font settings</summary>
-    <label style="display:block;margin-top:0.5rem;">Font for Main Message
+
+  <div class="step" data-step="3">
+    <h2>Style First Message</h2>
+    <p>How should this first message look?</p>
+    <label>Font
       <select id="fontMain" name="fontMain">
-        <option value="Poppins">Poppins</option>
-        <option value="Playfair Display">Playfair Display</option>
-        <option value="Dancing Script">Dancing Script</option>
-        <option value="Montserrat">Montserrat</option>
+        <option value="">Default</option>
+        <option>Poppins</option>
+        <option>Playfair Display</option>
+        <option>Dancing Script</option>
+        <option>Montserrat</option>
       </select>
     </label>
-    <label style="display:block;margin-top:0.5rem;">Font for Details
-      <select id="fontOther" name="fontOther">
-        <option value="Poppins">Poppins</option>
-        <option value="Playfair Display">Playfair Display</option>
-        <option value="Dancing Script">Dancing Script</option>
-        <option value="Montserrat">Montserrat</option>
+    <label>Text color <input type="color" id="mainTextColor" name="mainTextColor" value="#000000"></label>
+    <label>Outline color <input type="color" id="mainOutlineColor" name="mainOutlineColor" value="#000000"></label>
+    <label><input type="checkbox" id="mainBold" name="mainBold"> Bold</label>
+    <label><input type="checkbox" id="mainItalic" name="mainItalic"> Italic</label>
+    <label><input type="checkbox" id="mainCaps" name="mainCaps"> ALL CAPS</label>
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
+  </div>
+
+  <div class="step" data-step="4">
+    <h2>Follow-Up Message</h2>
+    <p>What message should appear next on the second screen?</p>
+    <input type="text" id="sub" name="sub">
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
+  </div>
+
+  <div class="step" data-step="5">
+    <h2>Style Follow-Up Message</h2>
+    <p>How should the second message look?</p>
+    <label>Font
+      <select id="fontSub" name="fontSub">
+        <option value="">Default</option>
+        <option>Poppins</option>
+        <option>Playfair Display</option>
+        <option>Dancing Script</option>
+        <option>Montserrat</option>
       </select>
     </label>
-  </details>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="button" class="next">Next</button>
+    <label>Text color <input type="color" id="subTextColor" name="subTextColor" value="#000000"></label>
+    <label>Outline color <input type="color" id="subOutlineColor" name="subOutlineColor" value="#000000"></label>
+    <label><input type="checkbox" id="subBold" name="subBold"> Bold</label>
+    <label><input type="checkbox" id="subItalic" name="subItalic"> Italic</label>
+    <label><input type="checkbox" id="subCaps" name="subCaps"> ALL CAPS</label>
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
   </div>
-</div>
-<div class="step" data-step="7">
-  <h2>Review and Launch</h2>
-  <div id="summary"></div>
-  <p><a id="resultLink" href="#" target="_blank"></a></p>
-  <div class="actions">
-    <button type="button" class="back">Back</button>
-    <button type="submit" id="launch">Launch My Reveal!</button>
+
+  <div class="step" data-step="6">
+    <h2>Ending Note</h2>
+    <p>Want to add a closing message or signature?</p>
+    <input type="text" id="from" name="from">
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
   </div>
-</div>
+
+  <div class="step" data-step="7">
+    <h2>Style Closing Note</h2>
+    <p>How should the closing message look?</p>
+    <label>Font
+      <select id="fontFrom" name="fontFrom">
+        <option value="">Default</option>
+        <option>Poppins</option>
+        <option>Playfair Display</option>
+        <option>Dancing Script</option>
+        <option>Montserrat</option>
+      </select>
+    </label>
+    <label>Text color <input type="color" id="fromTextColor" name="fromTextColor" value="#000000"></label>
+    <label>Outline color <input type="color" id="fromOutlineColor" name="fromOutlineColor" value="#000000"></label>
+    <label><input type="checkbox" id="fromBold" name="fromBold"> Bold</label>
+    <label><input type="checkbox" id="fromItalic" name="fromItalic"> Italic</label>
+    <label><input type="checkbox" id="fromCaps" name="fromCaps"> ALL CAPS</label>
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" class="next">Next</button>
+    </div>
+  </div>
+
+  <div class="step" data-step="8">
+    <h2>Add Photo (Optional)</h2>
+    <p>Want to include a circular photo?</p>
+    <input type="url" id="photo" name="photo" placeholder="https://example.com/photo.jpg">
+    <div class="nav">
+      <button type="button" class="back">Back</button>
+      <button type="button" id="generate">Generate My Link</button>
+    </div>
+  </div>
 </form>
+
+<div id="result" style="display:none;margin-top:1rem;">
+  <label>Your Link:<input type="text" id="resultUrl" readonly style="width:100%;"></label>
+</div>
+
 <script>
 const steps=document.querySelectorAll('.step');
-const total=steps.length;
-const stepNum=document.getElementById('stepNum');
-const stepTotal=document.getElementById('stepTotal');
-stepTotal.textContent=total;
+const progress=document.getElementById('progressBar');
+const progressText=document.getElementById('progressText');
 let current=0;
-function showStep(n){
-  steps.forEach((s,i)=>{s.classList.toggle('active',i===n);});
-  stepNum.textContent=n+1;
+function showStep(i){
+  steps.forEach((s,idx)=>s.classList.toggle('active',idx===i));
+  progress.value=i+1;
+  progressText.textContent=`Step ${i+1} of ${steps.length}`;
 }
-function next(){if(current<total-1){current++;showStep(current);}}
-function back(){if(current>0){current--;showStep(current);}}
-// event delegation for buttons
-document.getElementById('wizardForm').addEventListener('click',e=>{
-  if(e.target.classList.contains('next')){e.preventDefault();next();}
-  if(e.target.classList.contains('back')){e.preventDefault();back();}
+
+document.getElementById('wizard').addEventListener('click',e=>{
+  if(e.target.classList.contains('next')){ if(current<steps.length-1){current++; showStep(current);} }
+  if(e.target.classList.contains('back')){ if(current>0){current--; showStep(current);} }
 });
-// toggle fields
-document.querySelectorAll('input[name="hasPhoto"]').forEach(r=>r.addEventListener('change',()=>{
-  document.getElementById('photoField').style.display=document.querySelector('input[name="hasPhoto"]:checked').value==='yes'?'block':'none';
-}));
-document.querySelectorAll('input[name="hasDate"]').forEach(r=>r.addEventListener('change',()=>{
-  document.getElementById('dateField').style.display=document.querySelector('input[name="hasDate"]:checked').value==='yes'?'block':'none';
-}));
-document.querySelectorAll('input[name="hasFrom"]').forEach(r=>r.addEventListener('change',()=>{
-  document.getElementById('fromField').style.display=document.querySelector('input[name="hasFrom"]:checked').value==='yes'?'block':'none';
-}));
-document.querySelectorAll('input[name="color"]').forEach(r=>r.addEventListener('change',()=>{
-  document.getElementById('customColor').style.display=document.querySelector('input[name="color"]:checked').value==='custom'?'block':'none';
-}));
-function buildUrl(){
-  const base='https://bigreveal.joyjotstudio.store/';
+
+document.getElementById('generate').addEventListener('click',()=>{
   const params=new URLSearchParams();
-  params.set('main',document.getElementById('main').value.trim());
-  if(document.querySelector('input[name="hasPhoto"]:checked').value==='yes'){
-    params.set('photo',document.getElementById('photo').value.trim());
-  }
-  if(document.querySelector('input[name="hasDate"]:checked').value==='yes'){
-    params.set('date',document.getElementById('date').value.trim());
-  }
-  if(document.querySelector('input[name="hasFrom"]:checked').value==='yes'){
-    params.set('from',document.getElementById('from').value.trim());
-  }
-  let color=document.querySelector('input[name="color"]:checked').value;
-  if(color==='custom'){color=document.getElementById('colorHex').value.trim();}
-  params.set('color',color);
-  params.set('fontMain',document.getElementById('fontMain').value);
-  params.set('fontSub',document.getElementById('fontOther').value);
-  params.set('fontDate',document.getElementById('fontOther').value);
-  params.set('fontFrom',document.getElementById('fontOther').value);
-  return base+'?'+params.toString();
-}
-function updateSummary(){
-  const lines=[];
-  lines.push('Main: '+document.getElementById('main').value);
-  if(document.querySelector('input[name="hasPhoto"]:checked').value==='yes')
-    lines.push('Photo: '+document.getElementById('photo').value);
-  if(document.querySelector('input[name="hasDate"]:checked').value==='yes')
-    lines.push('Detail: '+document.getElementById('date').value);
-  if(document.querySelector('input[name="hasFrom"]:checked').value==='yes')
-    lines.push('From: '+document.getElementById('from').value);
-  lines.push('Color: '+document.querySelector('input[name="color"]:checked').value);
-  document.getElementById('summary').innerHTML='<ul><li>'+lines.join('</li><li>')+'</li></ul>';
-  const url=buildUrl();
-  const link=document.getElementById('resultLink');
-  link.href=url;link.textContent=url;
-}
-// update summary when entering final step
-steps[total-1].querySelector('#launch').addEventListener('mouseover',updateSummary);
-// handle submit
-document.getElementById('wizardForm').addEventListener('submit',e=>{
-  e.preventDefault();
-  updateSummary();
-  window.open(buildUrl(),'_blank');
+  const color=document.getElementById('color').value;
+  if(color) params.set('color',color);
+  const main=document.getElementById('main').value.trim();
+  if(main) params.set('main',main);
+  const fontMain=document.getElementById('fontMain').value;
+  if(fontMain) params.set('fontMain',fontMain);
+  const mainTextColor=document.getElementById('mainTextColor').value;
+  if(mainTextColor) params.set('mainTextColor',mainTextColor);
+  const mainOutlineColor=document.getElementById('mainOutlineColor').value;
+  if(mainOutlineColor) params.set('mainOutlineColor',mainOutlineColor);
+  if(document.getElementById('mainBold').checked) params.set('mainBold','1');
+  if(document.getElementById('mainItalic').checked) params.set('mainItalic','1');
+  if(document.getElementById('mainCaps').checked) params.set('mainCaps','1');
+
+  const sub=document.getElementById('sub').value.trim();
+  if(sub) params.set('sub',sub);
+  const fontSub=document.getElementById('fontSub').value;
+  if(fontSub) params.set('fontSub',fontSub);
+  const subTextColor=document.getElementById('subTextColor').value;
+  if(subTextColor) params.set('subTextColor',subTextColor);
+  const subOutlineColor=document.getElementById('subOutlineColor').value;
+  if(subOutlineColor) params.set('subOutlineColor',subOutlineColor);
+  if(document.getElementById('subBold').checked) params.set('subBold','1');
+  if(document.getElementById('subItalic').checked) params.set('subItalic','1');
+  if(document.getElementById('subCaps').checked) params.set('subCaps','1');
+
+  const from=document.getElementById('from').value.trim();
+  if(from) params.set('from',from);
+  const fontFrom=document.getElementById('fontFrom').value;
+  if(fontFrom) params.set('fontFrom',fontFrom);
+  const fromTextColor=document.getElementById('fromTextColor').value;
+  if(fromTextColor) params.set('fromTextColor',fromTextColor);
+  const fromOutlineColor=document.getElementById('fromOutlineColor').value;
+  if(fromOutlineColor) params.set('fromOutlineColor',fromOutlineColor);
+  if(document.getElementById('fromBold').checked) params.set('fromBold','1');
+  if(document.getElementById('fromItalic').checked) params.set('fromItalic','1');
+  if(document.getElementById('fromCaps').checked) params.set('fromCaps','1');
+
+  const photo=document.getElementById('photo').value.trim();
+  if(photo) params.set('photo',photo);
+
+  const url='https://customjc.netlify.app/?'+params.toString();
+  document.getElementById('resultUrl').value=url;
+  document.getElementById('result').style.display='block';
 });
+
 showStep(0);
 </script>
 </body>


### PR DESCRIPTION
## Summary
- replace `wizard.html` with a simplified 8‑step wizard
- each step covers a question from background color to optional photo
- progress indicator added
- JavaScript gathers selections and builds URL with only chosen parameters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68792e620b60832fae4c62e5266aa993