### PR TITLE
Add question prompts before page 1 style settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,9 +106,11 @@
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div>
+          <h2 class="form-step-question">What do you want your first big message to say?</h2>
           <label for="mainHeadline" class="block text-sm font-semibold text-gray-700 mb-2">Main Headline</label>
           <input id="mainHeadline" class="w-full px-4 py-3 border border-gray-300 rounded-lg" placeholder="We're Expecting!" required />
-          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mt-4 mb-2">Main Headline Font</label>
+          <h2 class="form-step-question">Which font should this message use?</h2>
+          <label for="fontMain" class="block text-sm font-semibold text-gray-700 mt-2 mb-2">Main Headline Font</label>
           <select id="fontMain" class="w-full px-4 py-3 border border-gray-300 rounded-lg">
             <option value="Poppins">Poppins</option>
             <option value="Playfair Display">Playfair Display</option>
@@ -123,6 +125,7 @@
           </select>
           <div class="grid grid-cols-2 gap-2 mt-4">
             <div>
+              <h2 class="form-step-question">What color should the text be?</h2>
               <label for="mainTextColor" class="block text-xs font-semibold text-gray-700 mb-1">Text Color</label>
               <select id="mainTextColor" class="w-full px-4 py-3 border border-gray-300 rounded-lg mb-1">
                 <option value="">Choose a color...</option>
@@ -146,6 +149,7 @@
               </div>
             </div>
             <div>
+              <h2 class="form-step-question">What outline color should it use?</h2>
               <label for="mainOutlineColor" class="block text-xs font-semibold text-gray-700 mb-1">Outline Color</label>
               <select id="mainOutlineColor" class="w-full px-4 py-3 border border-gray-300 rounded-lg mb-1">
                 <option value="">Use Default</option>
@@ -170,6 +174,7 @@
               </div>
             </div>
           </div>
+          <h2 class="form-step-question">Should any of these styles apply?</h2>
           <div class="flex items-center space-x-4 mt-2">
             <label class="text-xs"><input id="mainBold" type="checkbox" class="mr-1" />Bold</label>
             <label class="text-xs"><input id="mainItalic" type="checkbox" class="mr-1" />Italic</label>


### PR DESCRIPTION
## Summary
- insert prompt for main headline
- insert prompt for font selection
- add questions for text color, outline color and style options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68794bc6c148832f921e109e654ac08d